### PR TITLE
Added missing termUnit as enum to term object of subscription object

### DIFF
--- a/Microsoft.Marketplace.SaaS/2018-08-31/saasapi.v2.json
+++ b/Microsoft.Marketplace.SaaS/2018-08-31/saasapi.v2.json
@@ -943,6 +943,14 @@
               "endDate": {
                 "type": "string",
                 "format": "date-time"
+              },
+              "termUnit":{
+                "type": "string",
+                "enum": ["P1M", "P1Y"],
+                "x-ms-enum": {
+                  "name": "TermUnitEnum",
+                  "modelAsString": false
+                }
               }
             }
           },


### PR DESCRIPTION
Added the missing termUnit emun on the term object on the subscription object as described at https://docs.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-subscription-api